### PR TITLE
Remove redundant white space.

### DIFF
--- a/Scripts/Setup/selks-setup-ids-interface.sh
+++ b/Scripts/Setup/selks-setup-ids-interface.sh
@@ -75,7 +75,7 @@ do
   if [[ ${isitup} != "up"  ]]; then
       echo -e "\nThe specified interface - ${interface} - is not up."
       echo -e "Setting it up....\n"
-      ip link set "${interface}" up
+      ip link set dev "${interface}" up
   fi
   # we make sure we don't interfere with any static or dhcp settings in /etc/network/interfaces
   if ! grep --quiet "${interface}" /etc/network/interfaces ; then
@@ -83,10 +83,10 @@ do
       #auto enp0s8 
       #iface enp0s8 inet manual
       echo "# Stamus Networks SELKS ${interface} interface set up auto generated!" > /etc/network/interfaces.d/"${interface}"
-      echo -e "auto ${interface} \n" >> /etc/network/interfaces.d/"${interface}"
-      echo -e "iface ${interface} inet manual\n" >> /etc/network/interfaces.d/"${interface}"
-      echo -e "    up ip link set dev ${interface} up\n" >> /etc/network/interfaces.d/"${interface}"
-      echo -e "    down ip link set dev ${interface} down\n" >> /etc/network/interfaces.d/"${interface}"
+      echo -e "auto ${interface}" >> /etc/network/interfaces.d/"${interface}"
+      echo -e "iface ${interface} inet manual" >> /etc/network/interfaces.d/"${interface}"
+      echo -e "    up ip link set dev ${interface} up" >> /etc/network/interfaces.d/"${interface}"
+      echo -e "    down ip link set dev ${interface} down" >> /etc/network/interfaces.d/"${interface}"
   fi
 
 done


### PR DESCRIPTION
This patch removes some redundant white space in the interfaces configuration file for monitoring interfaces.
Also some extra fault tolerance for putting the interface up.