### PR TITLE
[SELKS5] Make sure the Moloch PCAP capture service runs as user logstash

### DIFF
--- a/Scripts/Configs/SELKS5/etc/systemd/system/molochpcapread-nonretain-selks.service
+++ b/Scripts/Configs/SELKS5/etc/systemd/system/molochpcapread-nonretain-selks.service
@@ -1,26 +1,13 @@
 [Unit]
 Description=Moloch Pcap Read
-After=network.target
-#Requires=network.target
-
-#After=network.target elasticsearch.service
-#Requires=network.target elasticsearch.service
+#After=elasticsearch.service
 
 [Service]
 Type=simple
-#Restart=on-failure
 StandardOutput=tty
-# Config line for executing pre start scripts
-#ExecStartPre=-/data/moloch/bin/moloch_config_interfaces.sh
-
-#Config line for not storing the pcaps. Suricata is in charge of pcap rotation/deletion.
-#Please look at pcap-log section in /etc/suricata/selks5-addin.yaml for more settings and info.
+User=logstash
+Group=logstash
 ExecStart=/bin/sh -c '/data/moloch/bin/moloch-capture -c /data/moloch/etc/config.ini -m -s -R /data/nsm/  >> /data/moloch/logs/capture.log 2>&1'
-
-#Config line for retaining the packet capture/pcaps on disk. Moloch is in charge of pcap rotation/deletion.
-#Please look at /data/moloch/etc/config.ini and https://github.com/aol/moloch/wiki/FAQ#pcap-deletion
-#for more for more settings and info.
-#ExecStart=/bin/sh -c '/data/moloch/bin/moloch-capture -c /data/moloch/etc/config.ini -m --copy --delete -R /data/nsm/  >> /data/moloch/logs/capture.log 2>&1'
 WorkingDirectory=/data/moloch
 LimitCORE=infinity
 Restart=always

--- a/Scripts/Configs/SELKS5/etc/systemd/system/molochpcapread-selks.service
+++ b/Scripts/Configs/SELKS5/etc/systemd/system/molochpcapread-selks.service
@@ -1,24 +1,12 @@
 [Unit]
 Description=Moloch Pcap Read
-After=network.target
-#Requires=network.target
-
-#After=network.target elasticsearch.service
-#Requires=network.target elasticsearch.service
+#After=elasticsearch.service
 
 [Service]
 Type=simple
-#Restart=on-failure
 StandardOutput=tty
-# Config line for executing pre start scripts
-#ExecStartPre=-/data/moloch/bin/moloch_config_interfaces.sh
-
-#Config line for not storing the pcaps. Suricata is in charge of pcap rotation/deletion.
-#Please look at pcap-log section in /etc/suricata/selks5-addin.yaml for more settings and info.
-#ExecStart=/bin/sh -c '/data/moloch/bin/moloch-capture -c /data/moloch/etc/config.ini -m -s -R /data/nsm/  >> /data/moloch/logs/capture.log 2>&1'
-
-#Default setting. Config line for retaining the packet capture/pcaps on disk. Moloch is in charge of pcap rotation/deletion.
-#Please look at /data/moloch/etc/config.ini for more for more settings and info.
+User=logstash
+Group=logstash
 ExecStart=/bin/sh -c '/data/moloch/bin/moloch-capture -c /data/moloch/etc/config.ini -m --copy --delete -R /data/nsm/  >> /data/moloch/logs/capture.log 2>&1'
 WorkingDirectory=/data/moloch
 LimitCORE=infinity

--- a/Scripts/Setup/selks-first-time-setup_stamus.sh
+++ b/Scripts/Setup/selks-first-time-setup_stamus.sh
@@ -73,6 +73,7 @@ do
             fi
             break;;
         NONE)
+            EXIT_STATUS="SUCCESS"
             break;;
      esac
 done

--- a/Scripts/Setup/selks-molochdb-init-setup_stamus.sh
+++ b/Scripts/Setup/selks-molochdb-init-setup_stamus.sh
@@ -69,7 +69,7 @@ firstboot_routine() {
 
         echo -e "\n### Setting up and restarting services ###\n"
         if id "logstash" >/dev/null 2>&1; then
-            chown logstash:logstash /data/moloch/ -R
+            chown logstash:logstash /data/moloch/raw/ -R
         fi
         /bin/systemctl disable molochcapture.service
         /bin/systemctl disable molochviewer.service

--- a/Scripts/Setup/selks-molochdb-init-setup_stamus.sh
+++ b/Scripts/Setup/selks-molochdb-init-setup_stamus.sh
@@ -69,7 +69,7 @@ firstboot_routine() {
 
         echo -e "\n### Setting up and restarting services ###\n"
         if id "logstash" >/dev/null 2>&1; then
-            chown logstash:logstash /data/moloch/raw/ -R
+            chown logstash:logstash /data/moloch/ -R
         fi
         /bin/systemctl disable molochcapture.service
         /bin/systemctl disable molochviewer.service


### PR DESCRIPTION
For the past few days I've been experiencing errors when trying to view and export PCAP files in Moloch, always receiving the error "No PCAP data has been found". In my viewer.log are the following errors:

`ERROR - Couldn't open file  { Error: EACCES: permission denied, open '/data/moloch/raw/jopen-181029-00000001.pcap'
    at Object.fs.openSync (fs.js:646:18)
    at Pcap.open (/data/moloch/viewer/pcap.js:100:16)
    at /data/moloch/viewer/viewer.js:3823:17
    at Immediate.setImmediate (/data/moloch/viewer/db.js:550:7)
    at runCallback (timers.js:794:20)
    at tryOnImmediate (timers.js:752:5)
    at processImmediate [as _immediateCallback] (timers.js:729:5)
  errno: -13,
  code: 'EACCES',
  syscall: 'open',
  path: '/data/moloch/raw/jopen-181029-00000001.pcap' }`

In Moloch under the menu 'Files' the file sizes are always reported as zero bytes. The files on disk are of normal size, confirming that Moloch is actually able to read them from /data/nsm and copy+merge them to /data/moloch/raw. But after that, they are basically lost.

The current systemd service files do not set the user as logstash, and for some reason this prevents Moloch from properly importing the PCAP files. I think it has to do with the service file starting the program with "/bin/bash -c". They are still imported to Elasticsearch because that happens after reading them from /data/nsm and so they will show up in the viewer, but the PCAP files cannot be viewed. By setting the user and group to logstash in the service file this functionality is restored. This can only be done for the pcapcapture service file, the viewer gives me errors saying the viewer.log file is not writable (even though it is).

I also removed a log of redundant comments from the service files, as this process is handled by the first-time-setup script and you can use the non-fpc version by disabling and enabling the correct services. The current comments suggest the recommended way is by editing the service files, but there are two separate for this exact purpose.

After this commit the PCAP files can be viewed, but Moloch still reports them as zero bytes. This will require further investigation.

Cheers,
Jeroen