### PR TITLE
Set permissions on Moloch log files.

### DIFF
--- a/Scripts/Setup/selks-molochdb-init-setup_stamus.sh
+++ b/Scripts/Setup/selks-molochdb-init-setup_stamus.sh
@@ -93,9 +93,9 @@ firstboot_routine() {
             chown logstash:logstash /data/moloch/raw/ -R
         fi
 	
-	chown -R logstash:logstash /data/moloch/logs/
+        chown -R logstash:logstash /data/moloch/logs/
         
-	/bin/systemctl disable molochcapture.service
+        /bin/systemctl disable molochcapture.service
         /bin/systemctl disable molochviewer.service
         /bin/systemctl enable molochpcapread-selks.service
         /bin/systemctl enable molochviewer-selks.service

--- a/Scripts/Setup/selks-molochdb-init-setup_stamus.sh
+++ b/Scripts/Setup/selks-molochdb-init-setup_stamus.sh
@@ -92,7 +92,10 @@ firstboot_routine() {
         if id "logstash" >/dev/null 2>&1; then
             chown logstash:logstash /data/moloch/raw/ -R
         fi
-        /bin/systemctl disable molochcapture.service
+	
+	chown -R logstash:logstash /data/moloch/logs/
+        
+	/bin/systemctl disable molochcapture.service
         /bin/systemctl disable molochviewer.service
         /bin/systemctl enable molochpcapread-selks.service
         /bin/systemctl enable molochviewer-selks.service


### PR DESCRIPTION
Moloch capture is unable to start because the logfile directory is not writable for user logstash. This fixes it.