### PR TITLE
Do not upgrade Moloch if it isn't installed

### DIFF
--- a/Scripts/Setup/selks-secondstage-upgrade_stamus
+++ b/Scripts/Setup/selks-secondstage-upgrade_stamus
@@ -26,6 +26,7 @@ if (( $EUID != 0 )); then
 fi
 
 SURI_CAPTURE_WASENABLED=""
+MOLOCH_INSTALLED=""
 
 echo -e "\e[1mNOTE:"
 echo -e "\e[1mStarting second stage upgrade sequence..."
@@ -40,15 +41,28 @@ fi
 
 /bin/systemctl stop kibana
 
-if [ "`/bin/systemctl is-active molochviewer-selks`" == "active" ] 
+if [ "`/bin/systemctl list-units --full --all | grep -F \"molochviewer-selks.service\"`" != "" ]
 then
-  /bin/systemctl stop molochviewer-selks
+  MOLOCH_INSTALLED="YES"
 fi
 
-if [ "`/bin/systemctl is-active molochpcapread-selks`" == "active" ] 
-then 
-  /bin/systemctl stop molochpcapread-selks
-fi 
+if [ "`/bin/systemctl list-units --full --all | grep -F \"molochpcapread-selks.service\"`" != "" ]
+then
+  MOLOCH_INSTALLED="YES"
+fi
+
+if  [ "$MOLOCH_INSTALLED" == "YES" ]
+then
+  if [ "`/bin/systemctl is-active molochviewer-selks`" == "active" ] 
+  then
+    /bin/systemctl stop molochviewer-selks
+  fi
+  
+  if [ "`/bin/systemctl is-active molochpcapread-selks`" == "active" ] 
+  then 
+    /bin/systemctl stop molochpcapread-selks
+  fi
+fi
 
 apt-get update && apt-get dist-upgrade
 
@@ -59,42 +73,48 @@ chown -R kibana /usr/share/kibana/optimize/
 /usr/bin/supervisorctl restart scirius 
 
 # Moloch upgrade
-moloch_latest=$(curl  https://api.github.com/repos/aol/moloch/tags  -s |jq -r '.[0].name' | cut -c 2-)
-moloch_current=$(dpkg -l |grep moloch | awk '{print $3}')
-
-if dpkg --compare-versions ${moloch_latest} gt ${moloch_current} ; then
-  echo -e "\e[1m\nUpgrading Moloch.."
-  echo -e "\e[0m"
-  mkdir -p /opt/molochtmp
-  cd /opt/molochtmp/
+if  [ "$MOLOCH_INSTALLED" == "YES" ]
+then
+  moloch_latest=$(curl  https://api.github.com/repos/aol/moloch/tags  -s |jq -r '.[0].name' | cut -c 2-)
+  moloch_current=$(dpkg -l |grep moloch | awk '{print $3}')
   
-  if /usr/bin/wget -q --timeout=10s --tries=1  https://files.molo.ch/builds/ubuntu-18.04/moloch_${moloch_latest}-1_amd64.deb ; then
-    if  ( curl -4 --retry 4 --retry-connrefused --retry-delay 30 -X GET "localhost:9200/_cluster/health?wait_for_status=yellow&timeout=240s" )
-    then
-      dpkg -i /opt/molochtmp/moloch_${moloch_latest}-1_amd64.deb 
-      printf 'UPGRADE\n' | /data/moloch/db/db.pl http://localhost:9200 upgrade
-      rm /opt/molochtmp/moloch_${moloch_latest}-1_amd64.deb
+  if dpkg --compare-versions ${moloch_latest} gt ${moloch_current} ; then
+    echo -e "\e[1m\nUpgrading Moloch.."
+    echo -e "\e[0m"
+    mkdir -p /opt/molochtmp
+    cd /opt/molochtmp/
+    
+    if /usr/bin/wget -q --timeout=10s --tries=1  https://files.molo.ch/builds/ubuntu-18.04/moloch_${moloch_latest}-1_amd64.deb ; then
+      if  ( curl -4 --retry 4 --retry-connrefused --retry-delay 30 -X GET "localhost:9200/_cluster/health?wait_for_status=yellow&timeout=240s" )
+      then
+        dpkg -i /opt/molochtmp/moloch_${moloch_latest}-1_amd64.deb 
+        printf 'UPGRADE\n' | /data/moloch/db/db.pl http://localhost:9200 upgrade
+        rm /opt/molochtmp/moloch_${moloch_latest}-1_amd64.deb
+      else
+        echo "\e[1m\nMoloch will not be upgraded!! Please check that Elasticsearch is up and running."
+        echo -e "\e[0m"
+        exit 1;
+      fi
+      
+      echo -e "\e[1m\nStarting Moloch SELKS services.. "
+      echo -e "\e[0m"
+      /bin/systemctl start molochpcapread-selks.service
+      /bin/systemctl start molochviewer-selks.service
     else
-      echo "\e[1m\nMoloch will not be upgraded!! Please check that Elasticsearch is up and running."
+      /bin/systemctl start molochpcapread-selks.service
+      /bin/systemctl start molochviewer-selks.service
+      echo "\e[1m\nCould not download and upgrade Moloch. Please check your network connection or that Elasticsearch is up and running."
       echo -e "\e[0m"
       exit 1;
     fi
     
-    echo -e "\e[1m\nStarting Moloch SELKS services.. "
-    echo -e "\e[0m"
-    /bin/systemctl start molochpcapread-selks.service
-    /bin/systemctl start molochviewer-selks.service
   else
     /bin/systemctl start molochpcapread-selks.service
     /bin/systemctl start molochviewer-selks.service
-    echo "\e[1m\nCould not download and upgrade Moloch. Please check your network connection or that Elasticsearch is up and running."
-    echo -e "\e[0m"
-    exit 1;
   fi
-  
 else
-  /bin/systemctl start molochpcapread-selks.service
-  /bin/systemctl start molochviewer-selks.service
+  echo -e "\e[1mNOTE:"
+  echo "Moloch reader/viewer not installed. Not upgrading."
 fi
 
 if  [ "$SURI_CAPTURE_WASENABLED" == "YES" ] 


### PR DESCRIPTION
If Moloch isn't installed during the initial setup this script can cause problems when it tries to interact with the Moloch services.